### PR TITLE
Spw 14286 update local postgres docker image to support pg hint plan

### DIFF
--- a/14-circle/Dockerfile
+++ b/14-circle/Dockerfile
@@ -24,17 +24,19 @@ ENV POSTGRES_MASTER_SERVICE_PORT 5432
 
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+    	   gawk \
            # ca-certificates: for accessing remote raster files;
            #   fix: https://github.com/postgis/docker-postgis/issues/307
            ca-certificates \
            \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+    	   postgresql-$PG_MAJOR-pg-hint-plan \
       && rm -rf /var/lib/apt/lists/*
 
 RUN apt update && \

--- a/14-circle/initdb-postgis.sh
+++ b/14-circle/initdb-postgis.sh
@@ -24,7 +24,7 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-	echo "Loading PostGIS extensions into $DB"
+	echo "Loading PostGIS, fuzzystrmatch, vector, unaccent and pg_hint_plan extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
@@ -41,7 +41,7 @@ done
 
 # Load PG_TRGM into both template1 and $POSTGRES_DB
 for DB in template1 "$POSTGRES_DB"; do
-	echo "Loading PG_TRGM extensions into $DB"
+	echo "Loading PG_TRGM, vector, unaccent and pg_hint_plan extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS pg_trgm;
         CREATE EXTENSION IF NOT EXISTS vector;

--- a/14-circle/initdb-postgis.sh
+++ b/14-circle/initdb-postgis.sh
@@ -5,6 +5,7 @@ set -e
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
 
+# This gawk operation adds pg_hint_plan to shared_preload_libraries if it isn't added.
 gawk '/^#shared_preload_libraries/ { sub(/^#/, "") }
      /^shared_preload_libraries/ {
          if ($3 == "\047\047") {

--- a/14-circle/initdb-postgis.sh
+++ b/14-circle/initdb-postgis.sh
@@ -5,6 +5,17 @@ set -e
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
 
+gawk '/^#shared_preload_libraries/ { sub(/^#/, "") }
+     /^shared_preload_libraries/ {
+         if ($3 == "\047\047") {
+             sub(/\047\047/, "\047pg_hint_plan\047");
+         } else if ($0 !~ /pg_hint_plan/) {
+             match($0, /\047([^\047]*)/, arr);
+             sub(/\047([^\047]*)/, "\047" arr[1] ", pg_hint_plan");
+         }
+     }
+     {print}' $PGDATA/postgresql.conf > ~/tmp.conf && mv ~/tmp.conf $PGDATA/postgresql.conf
+
 # Create the 'template_postgis' template db
 "${psql[@]}" <<- 'EOSQL'
 CREATE DATABASE template_postgis IS_TEMPLATE true;
@@ -23,6 +34,7 @@ for DB in template_postgis "$POSTGRES_DB"; do
 		CREATE EXTENSION IF NOT EXISTS postgis_tiger_geocoder;
         CREATE EXTENSION IF NOT EXISTS vector;
         CREATE EXTENSION IF NOT EXISTS unaccent;
+    CREATE EXTENSION IF NOT EXISTS pg_hint_plan;
 EOSQL
 done
 
@@ -33,5 +45,6 @@ for DB in template1 "$POSTGRES_DB"; do
 		CREATE EXTENSION IF NOT EXISTS pg_trgm;
         CREATE EXTENSION IF NOT EXISTS vector;
         CREATE EXTENSION IF NOT EXISTS unaccent;
+    CREATE EXTENSION IF NOT EXISTS pg_hint_plan;
 EOSQL
 done

--- a/14/Dockerfile
+++ b/14/Dockerfile
@@ -24,17 +24,19 @@ ENV POSTGRES_MASTER_SERVICE_PORT 5432
 
 
 ENV POSTGIS_MAJOR 3
-ENV POSTGIS_VERSION 3.4.2+dfsg-1.pgdg110+1
+ENV POSTGIS_VERSION 3.5.1+dfsg-1.pgdg110+1
 
 RUN apt-get update \
       && apt-cache showpkg postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR \
       && apt-get install -y --no-install-recommends \
+           gawk \
            # ca-certificates: for accessing remote raster files;
            #   fix: https://github.com/postgis/docker-postgis/issues/307
            ca-certificates \
            \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR=$POSTGIS_VERSION \
            postgresql-$PG_MAJOR-postgis-$POSTGIS_MAJOR-scripts \
+	       postgresql-$PG_MAJOR-pg-hint-plan \
       && rm -rf /var/lib/apt/lists/*
 
 RUN apt update && \
@@ -42,4 +44,6 @@ RUN apt update && \
 
 RUN mkdir -p /docker-entrypoint-initdb.d
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
+COPY ./fix.sh /usr/local/bin/fix.sh
 
+RUN chmod a+x /usr/local/bin/fix.sh

--- a/14/fix.sh
+++ b/14/fix.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -Eeo pipefail
+
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --no-psqlrc )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
+
+	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
+}
+
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		printf >&2 'error: both %s and %s are set (but are exclusive)\n' "$var" "$fileVar"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+	: "${POSTGRES_HOST_AUTH_METHOD:=}"
+
+	declare -g DATABASE_ALREADY_EXISTS
+	: "${DATABASE_ALREADY_EXISTS:=}"
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+docker_setup_env
+
+psql=( docker_process_sql )
+
+
+gawk '/^#shared_preload_libraries/ { sub(/^#/, "") }
+     /^shared_preload_libraries/ {
+         if ($3 == "\047\047") {
+             sub(/\047\047/, "\047pg_hint_plan\047");
+         } else if ($0 !~ /pg_hint_plan/) {
+             match($0, /\047([^\047]*)/, arr);
+             sub(/\047([^\047]*)/, "\047" arr[1] ", pg_hint_plan");
+         }
+     }
+     {print}' $PGDATA/postgresql.conf > ~/tmp.conf && mv ~/tmp.conf $PGDATA/postgresql.conf
+
+for DB in template_postgis template1 "$POSTGRES_DB"; do
+	echo "Loading PostGIS extensions into $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+    CREATE EXTENSION IF NOT EXISTS pg_hint_plan;
+    ALTER EXTENSION postgis UPDATE;
+    ALTER EXTENSION postgis_topology UPDATE;
+    ALTER EXTENSION postgis_tiger_geocoder UPDATE;
+EOSQL
+done

--- a/14/fix.sh
+++ b/14/fix.sh
@@ -60,12 +60,19 @@ gawk '/^#shared_preload_libraries/ { sub(/^#/, "") }
      }
      {print}' $PGDATA/postgresql.conf > ~/tmp.conf && mv ~/tmp.conf $PGDATA/postgresql.conf
 
-for DB in template_postgis template1 "$POSTGRES_DB"; do
-	echo "Loading PostGIS extensions into $DB"
+for DB in template_postgis "$POSTGRES_DB"; do
+	echo "Enabling pg_hint_plan and updating PostGIS extensions on $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
     CREATE EXTENSION IF NOT EXISTS pg_hint_plan;
     ALTER EXTENSION postgis UPDATE;
     ALTER EXTENSION postgis_topology UPDATE;
     ALTER EXTENSION postgis_tiger_geocoder UPDATE;
+EOSQL
+done
+
+for DB in template1; do
+	echo "Enabling pg_hint_plan on $DB"
+	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
+    CREATE EXTENSION IF NOT EXISTS pg_hint_plan;
 EOSQL
 done

--- a/14/initdb-postgis.sh
+++ b/14/initdb-postgis.sh
@@ -24,7 +24,7 @@ EOSQL
 
 # Load PostGIS into both template_database and $POSTGRES_DB
 for DB in template_postgis "$POSTGRES_DB"; do
-	echo "Loading PostGIS extensions into $DB"
+	echo "Loading PostGIS, fuzzystrmatch, vector, unaccent and pg_hint_plan extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS postgis;
 		CREATE EXTENSION IF NOT EXISTS postgis_topology;
@@ -41,7 +41,7 @@ done
 
 # Load PG_TRGM into both template1 and $POSTGRES_DB
 for DB in template1 "$POSTGRES_DB"; do
-	echo "Loading PG_TRGM extensions into $DB"
+	echo "Loading PG_TRGM, vector, unaccent and pg_hint_plan extensions into $DB"
 	"${psql[@]}" --dbname="$DB" <<-'EOSQL'
 		CREATE EXTENSION IF NOT EXISTS pg_trgm;
         CREATE EXTENSION IF NOT EXISTS vector;

--- a/14/initdb-postgis.sh
+++ b/14/initdb-postgis.sh
@@ -5,6 +5,7 @@ set -e
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
 
+# This gawk operation adds pg_hint_plan to shared_preload_libraries if it isn't added.
 gawk '/^#shared_preload_libraries/ { sub(/^#/, "") }
      /^shared_preload_libraries/ { 
          if ($3 == "\047\047") {


### PR DESCRIPTION
This PR enables `pg_hint_plan` extension for local development and CI using this docker container.

Also, the version of PostGIS that we were using before wasn't available in the debian apt repo. I had to update that extension as well.

There is also a `fix.sh` executable to enable `pg_hint_plan` extension and update the PostGIS extension version used by the database as the older version doesn't exist in this container.

To do that, connect to the container through shell, and execute `fix.sh` in any directory:
![image](https://github.com/user-attachments/assets/d2eaf403-d1fc-49fe-aad6-312d1aaf81cd)

